### PR TITLE
Save config to standard directories

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,9 +4,27 @@ var path = require('path')
 var _ = require('lodash')
 var home = require('os-homedir')
 
-var configPath = path.join(home(), '.greenkeeperrc')
-
 var config
+
+var configDirs = {
+  'linux': path.join(home(), '.config'),
+  'darwin': path.join(home(), 'Library', 'Preferences'),
+  'win32': path.join(home(), 'AppData', 'Roaming'),
+  'default': home()
+}
+
+var getConfigDir = function () {
+  // If configuration exists in the old default path use it
+  try {
+    fs.accessSync(path.join(configDirs.default, '.greenkeeperrc'))
+    return configDirs.default
+  } catch (err) {
+    // Use XDG environment variable and fallback to OS default
+    return process.env.XDG_CONFIG_HOME || configDirs[process.platform]
+  }
+}
+
+var configPath = path.join(getConfigDir(), '.greenkeeperrc')
 
 try {
   config = JSON.parse(fs.readFileSync(configPath))

--- a/index.js
+++ b/index.js
@@ -2,25 +2,19 @@ var fs = require('fs')
 var path = require('path')
 
 var _ = require('lodash')
+var envPaths = require('env-paths')
 var home = require('os-homedir')
 
 var config
 
-var configDirs = {
-  'linux': path.join(home(), '.config'),
-  'darwin': path.join(home(), 'Library', 'Preferences'),
-  'win32': path.join(home(), 'AppData', 'Roaming'),
-  'default': home()
-}
-
 var getConfigDir = function () {
   // If configuration exists in the old default path use it
   try {
-    fs.accessSync(path.join(configDirs.default, '.greenkeeperrc'))
-    return configDirs.default
+    fs.accessSync(path.join(home(), '.greenkeeperrc'))
+    return home()
   } catch (err) {
     // Use XDG environment variable and fallback to OS default
-    return process.env.XDG_CONFIG_HOME || configDirs[process.platform]
+    return envPaths('', {suffix: ''}).config
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "url": "https://github.com/greenkeeperio/rc/issues"
   },
   "dependencies": {
+    "env-paths": "^0.3.0",
     "lodash": "^4.11.1",
     "os-homedir": "^1.0.1"
   },


### PR DESCRIPTION
Instead of placing the configuration file in the home directory it should be placed in the appropriate directory per OS. This doesn't introduce any breaking changes since it falls back to using the configuration in the home directory.
Atom has [the same issue open](https://github.com/atom/atom/issues/8281), I got most of the paths and how to to implement this gracefully from there.