### PR TITLE
Save config to standard directories

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
     "url": "https://github.com/greenkeeperio/rc/issues"
   },
   "dependencies": {
+    "env-paths": "^0.3.0",
     "lodash": "^4.11.1",
+    "mkdirp": "^0.5.1",
     "os-homedir": "^1.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
The config is read to and written from standard config directories using the "env-paths" module,
rather than just stuffing it into the home directory.
Old config files will automatically be migrated to the new location.

BREAKING CHANGE: Config is no longer stored in `~/.greenkeeperrc`

Based on #3, adding migration from the old path.